### PR TITLE
Hash arguments list more robustly.

### DIFF
--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -1,3 +1,6 @@
+import hashlib
+import pickle
+
 # local dependencies
 from .version import __version__
 
@@ -168,9 +171,9 @@ def _prepare_key(key, *args, **kwargs):
     items = kwargs.items()
     items.sort()
     hashable_args = (args, tuple(items))
-    args_key = hash(hashable_args)
+    args_key = hashlib.md5(pickle.dumps(hashable_args)).hexdigest()
 
-    return "%s/args:%x" % (key, args_key)
+    return "%s/args:%s" % (key, args_key)
 
 
 class LocalCache:


### PR DESCRIPTION
Apparently, python's hash() function does not return consistent results across python sessions. It's useful to be able to cache calls in one process and read them in another, so that's a problem. To get consistent hashes, use pickle.dumps to get a string representation of arguments, and hashlib.md5 to hash the result.

Note that pickle could be made faster by specifying a 2nd parameter at the expense of losing compatibility with older versions of python. http://docs.python.org/library/pickle.html
