### PR TITLE
Python 2-3 compatible

### DIFF
--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -168,8 +168,7 @@ def _prepare_key(key, *args, **kwargs):
     if not args and not kwargs:
         return key
 
-    items = kwargs.items()
-    items.sort()
+    items = sorted(kwargs.items())
     hashable_args = (args, tuple(items))
     args_key = hashlib.md5(pickle.dumps(hashable_args)).hexdigest()
 

--- a/test/cache_test.py
+++ b/test/cache_test.py
@@ -118,7 +118,7 @@ def test_hash_arguments():
     expensive(1, foo=2)
     expensive(2, foo=3)
 
-    keys = backend._cache.keys()
+    keys = list(backend._cache.keys())
 
     assert len(keys) == 2, "only two keys are set"
     assert ("mykey/args:") in keys[0]


### PR DESCRIPTION
Confirmed `make test` exits successfully with Python 2.7.12 and 3.5.2